### PR TITLE
Build and release Windows binaries

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,66 @@
+name: Build
+
+env:
+  Configuration: Release
+  Artifacts: build/Release
+  Branch: ${{github.ref_name}}
+  
+on:
+  push:
+    Branches: $Branch
+  pull_request:
+    Branches: $Branch
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  Windows:
+    runs-on: windows-latest
+    steps:
+
+    - name: Clone repo and submodules
+      run: git clone --recurse-submodules https://github.com/${{github.repository}}.git .
+
+    - name: Get current date, commit hash and count
+      run: |
+        echo "CommitDate=$(git show -s --date=format:'%Y-%m-%d' --format=%cd)" >> $env:GITHUB_ENV
+        echo "CommitHashShort=$(git rev-parse --short=7 HEAD)" >> $env:GITHUB_ENV
+        echo "CommitCount=$(git rev-list --count ${{env.Branch}})" >> $env:GITHUB_ENV
+
+    - name: Install Qt
+      uses: jurplel/install-qt-action@v4
+      with:
+        version: '6.6.0'
+        host: 'windows'
+        target: 'desktop'
+        arch: 'win64_msvc2019_64'
+        modules: 'addons.qtmultimedia'
+
+    - name: Build
+      run: |
+        cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.Configuration}}
+        cmake --build ${{github.workspace}}/build --config ${{env.Configuration}}
+        windeployqt.exe "${{github.workspace}}/${{env.Artifacts}}/bino.exe"
+
+    - name: Upload Installer Artifact to GitHub
+      uses: actions/upload-artifact@v2
+      with:
+        name: "${{github.event.repository.name}}_r${{env.CommitCount}}@${{env.CommitHashShort}}"
+        path: "${{github.workspace}}/${{env.Artifacts}}/"
+
+    - name: Compress artifacts
+      uses: vimtor/action-zip@v1.1
+      with:
+        files: '${{env.Artifacts}}/'
+        dest: "build/${{github.event.repository.name}}_r${{env.CommitCount}}@${{env.CommitHashShort}}.zip"
+
+    - name: GitHub pre-release
+      uses: "marvinpinto/action-automatic-releases@latest"
+      with:
+        repo_token: "${{secrets.GITHUB_TOKEN}}"
+        automatic_release_tag: "latest"
+        prerelease: false
+        title: "[${{env.CommitDate}}] ${{github.event.repository.name}} r${{env.CommitCount}}@${{env.CommitHashShort}}"
+        files: "build/${{github.event.repository.name}}_r${{env.CommitCount}}@${{env.CommitHashShort}}.zip"


### PR DESCRIPTION
Adds a GitHub actions workflow to compile Win64 executable with dependencies and uploads them to the [workflow](https://github.com/ThreeDeeJay/bino/actions/runs/9986627249) and [releases](https://github.com/ThreeDeeJay/bino/releases) for people to download easily without an account. It uses the date, commit number (`r###`) and commit hash (`@abc1234`) for versioning, though if needed I think I could also prepend the lastest tag (`bino-2.2` or whichever is the most recent at the time of compilation). Also, keep in mind that the [latest release](https://github.com/ThreeDeeJay/bino/releases/tag/latest) will get rewritten on every build.
![bino_wmDQ06Otop](https://github.com/user-attachments/assets/f5c3ab8d-d592-4d3c-9d74-80572143e75f)
